### PR TITLE
Added initial support for Markdown .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Current release 0.1 with the following features.
  - Allows specification of a different output directory
  - Allows specification of a stylesheet through linking a stylesheet URL
  - Automatically generates an index.html file with relative links to each of the generated html files
-
+ - Markdown support: header(1,2,3), link, bold text, italic text
 
 ## Tool options
 ```
@@ -65,6 +65,28 @@ Sample code for using output and stylesheet options below:
 The order for using options doesn't matter, **but** the file, directory or url has to follow the used option.
 
 In the case that an output directory isn't indicated or valid, the generator will create files in a default ./dist folder in the current working directory.
+
+----
+## Markdown 
+The tool supports Markdown (.md) files. 
+### Headers
+```
+# H1 
+## H2
+## H3
+```
+### Links
+```
+[I'm an inline-style link](https://github.com)
+```
+### Bold & Italic
+```
+**bold text**
+
+**italic text**
+
+***bold and italic text***
+```
 
 ----
 ## Generated Pages live example

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ The tool supports Markdown (.md) files.
 ***bold and italic text***
 ```
 
+| Markdown syntax | HTML equivalent |
+| ------------ | -------- |
+|Header 1|`<h1>Test</h1>`| 
+|Header 2| `<h2>Test</h2>`|
+|Header 3| `<h3>Test</h3>`|
+|Bold| `<b>Test</b>`|
+|Italic| `<i>Test</i>`|
+|Link | `<a href='URL'>Test</a>`|
+
 ----
 ## Generated Pages live example
 [Link to the example webpage](https://rclee91.github.io/SiteGen/)

--- a/bin/index.js
+++ b/bin/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { Transform } = require('stream');
 const { Command } = require('commander');
 
-const extensions = [".txt"];
+const extensions = [".txt", ".md"];
 
 //path to current directory for dist folder
 const dist = path.join(process.cwd(), "dist");
@@ -171,6 +171,7 @@ function createFile(filepath, extension){
     }
 }
 
+
 /*
   Function gets the htmlContent to be written into html files
 
@@ -187,14 +188,17 @@ function htmlContent(data, filename, extension){
     let bodyContent = "";
 
     //Processing files ending with extensions in the extensions array
-    if(typeof data === "string" && extension != ".html") {
+    if(typeof data === "string" && extension == ".txt") {
         let lines = data.split(/\r?\n\r?\n\r?\n/);
         if(lines.length > 1){
             title = lines[0];
             lines.shift();
         }
         bodyContent += lines[0].split(/\r?\n\r?\n/g).map(line => `\r\n\t\t<p>${line}</p>`).join("\n");
-    } else{ //Creating index.html
+    } else if(typeof data == "string" && extension == ".md") {
+        bodyContent = markdownContent(data, filename)
+    }
+    else{ //Creating index.html
         title = "Generated Pages";
         if(Array.isArray(data)){
             data.forEach(filename =>{
@@ -219,6 +223,33 @@ function htmlContent(data, filename, extension){
                         '\r\n\t</body>\r\n</html>';
 
     return htmlContent;
+}
+
+// Creates Markdown content
+function markdownContent(data, filename) {
+    /*
+    Function creates Markdown content for the html file. 
+    Added support for the following features. 
+    
+    Parameters
+    data - string: text data from .md file
+    filename - string: name of the file 
+
+    Returns
+    html - string: content of the html file
+    */
+    console.log(filename)
+    // Using replace method on string & regular expression 
+    const convertedText = data
+        .replace(/^# (.*$)/gim, '<h1>$1</h1>') // Heading 1 
+		.replace(/^### (.*$)/gim, '<h3>$1</h3>') // Heading 3 
+		.replace(/^## (.*$)/gim, '<h2>$1</h2>') // Heading 2
+		.replace(/\*\*(.*)\*\*/gim, '<b>$1</b>') // Bold
+		.replace(/\*(.*)\*/gim, '<i>$1</i>') // Italic
+        .replace(/\[(.*?)\]\((.*?)\)/gim, "<a href='$2'>$1</a>") // Link 
+		.replace(/\n$/gim, '<br />') // Break line
+
+    return convertedText
 }
 
 /*

--- a/bin/index.js
+++ b/bin/index.js
@@ -243,7 +243,9 @@ function markdownContent(data) {
 		.replace(/^### (.*$)/gim, '<h3>$1</h3>') // Heading 3 
 		.replace(/^## (.*$)/gim, '<h2>$1</h2>') // Heading 2
 		.replace(/\*\*(.*)\*\*/gim, '<b>$1</b>') // Bold
-		.replace(/\*(.*)\*/gim, '<i>$1</i>') // Italic
+        .replace(/\*(.*)\*/gim, '<i>$1</i>') // Italic
+        .replace(/\*\*(.*)\*\*/gim, '<b>$1</b>') // Bold nested in Italic
+        .replace(/\*(.*)\*/gim, '<i>$1</i>') // Italic nested in Bold
         .replace(/\[(.*?)\]\((.*?)\)/gim, "<a href='$2'>$1</a>") // Link 
 		.replace(/\n$/gim, '<br />') // Break line
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -188,7 +188,7 @@ function htmlContent(data, filename, extension){
     let bodyContent = "";
 
     //Processing files ending with extensions in the extensions array
-    if(typeof data === "string" && extension == ".txt") {
+    if (typeof data === "string" && extension == ".txt") {
         let lines = data.split(/\r?\n\r?\n\r?\n/);
         if(lines.length > 1){
             title = lines[0];
@@ -226,19 +226,17 @@ function htmlContent(data, filename, extension){
 }
 
 // Creates Markdown content
-function markdownContent(data, filename) {
-    /*
+/*
     Function creates Markdown content for the html file. 
     Added support for the following features. 
     
     Parameters
     data - string: text data from .md file
-    filename - string: name of the file 
 
     Returns
     html - string: content of the html file
     */
-    console.log(filename)
+function markdownContent(data) {
     // Using replace method on string & regular expression 
     const convertedText = data
         .replace(/^# (.*$)/gim, '<h1>$1</h1>') // Heading 1 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "homepage": "https://github.com/rclee91/SiteGen#readme",
   "bin": {
     "sitegen": "./bin/index.js"
+  },
+  "dependencies": {
+    "commander": "^8.2.0"
   }
 }


### PR DESCRIPTION
Closes #4 

Added Markdown .md file support to the tool. What I have done: 
- Created a function _markdownContent_, that parses Markdown data and returns data converted to HTML code.  
- Function _htmlContent_: provided if statement check to determine the correct file extension for Markdown (.md) files. Once the Markdown (.md) file has been determined, the new function _markdownContent_ will be called to process that file and populate a content for HTML. 
- Updated documentation for Markdown support feature.

To parse Markdown data, I have used [a method from String JavaScript object - replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace). I have provided regular expressions to match the following Markdown syntax: 

| Markdown syntax | HTML equivalent |
| ------------ | -------- |
|Header 1|`<h1>Test</h1>`| 
|Header 2| `<h2>Test</h2>`|
|Header 3| `<h3>Test</h3>`|
|Bold| `<b>Test</b>`|
|Italic| `<i>Test</i>`|
|Link | `<a href='URL'>Test</a>`|

For the testing purposes, I have created Markdown (.md) file with the following content: 
```
# Testing Heading & Title 

## Testing Heading 2 
## Testing Heading 3

[Testing link](https://github.com/)
**testing bold text** Hello it's me can you hear me ? 
*testing italic text*

***testing both bold and italic text***
```

If you find any issues regarding the Markdown support, please inform me. 

