### PR TITLE
Support --config with Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Current release 0.1 with the following features.
  - Allows specification of a stylesheet through linking a stylesheet URL
  - Automatically generates an index.html file with relative links to each of the generated html files
  - Markdown support: header(1,2,3), link, bold text, italic text, inline code, horizontal rule
+ - Config JSON file cotaining SSG options support
 
 ## Tool options
 ```
@@ -19,6 +20,7 @@ Current release 0.1 with the following features.
   -i, --input <file or directory name>       Designate an input file or directory
   -o, --output <directory name>              Designate an output directory, default ./dist
   -s, --stylesheet <stylesheet URL>          Link a stylesheet URL to the html
+  -c, --config <file>                        Read and parse json properties from file as options.
   -h, --help                                 Lists all available options
 ```
 
@@ -111,6 +113,29 @@ Three or more "---"
 |Horizontal Rule | `<hr>` |
 
 ----
+## Config file: 
+
+The tool support `.json` config file
+
+### Usage
+
+```sh
+sitegen -c config.json
+```
+
+Reading and parsing json properties as options for `sitegen`
+**Note**: if `-c` exists, other options are be ignored. 
+
+### Example.json 
+```json
+{
+  "input": "./testfiles",
+  "output": "./output",
+  "stylesheet": "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css",
+  "lang": "en"
+}
+```
+
 ## Generated Pages live example
 [Link to the example webpage](https://rclee91.github.io/SiteGen/)
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,34 +13,54 @@ const dist = path.join(process.cwd(), "dist");
 let outputPath = dist;
 
 //stylesheet url
-let stylesheetUrl = "";
+let stylesheetUrl = undefined;
 
 const program = new Command();
 program
     .version(`Name: ${pkjson.name} \nVersion: ${pkjson.version}`, '-v, --version', 'Output the current version')
-    .requiredOption('-i, --input <file or directory', 'Designate an input file or directory')
+    .option('-i, --input <file or directory>', 'Designate an input file or directory')
     .option('-o, --output <directory>', 'Designate an ouput directory', dist)
     .option('-s, --stylesheet <stylesheet url>', 'Link to a stylesheet url', '')
+    .option('-c, --config <config json file>', 'Link to file that specifies all SSG options')
     .showHelpAfterError();
 program.parse(process.argv);
 
 const options = program.opts();
+//Config file option
+if(options.config !== undefined) {
+    try {
+        let configData = fs.readFileSync(options.config);
+        let configOptions = JSON.parse(configData); 
+        for(const [key, value] of Object.entries(configOptions)) {
+            value || value.length > 0 ? options[`${key}`] = `${value}` : options[`${key}`] = undefined;
+        }
+        if(!options.input) {
+            console.log(`error: input <file or directory> is not specified in config file ${options.config}`);
+            process.exit(-1);
+        }
+    } catch(error) {
+        console.error(`Can't read or parse config file ${options.config}\n ${error}`);
+    }
+}
 //Output option
 if(options.output !== dist){
     if(fs.existsSync(options.output)){
         outputPath = options.output;
     }
     else{
-        console.log(`Output directory "${options.output}" doesn't exist, outputting all files to ./dist`);
+        console.log(`Output directory ${options.output} doesn't exist, outputting all files to ./dist`);
     }
 }
 //Stylesheet option
-if(options.stylesheet !== '')
+if(options.stylesheet !== undefined)
     stylesheetUrl = options.stylesheet;
 //Input option
 if(options.input !== undefined)
     processInput(options.input);
-
+else {
+    console.error("error: required option input <file or directory> is not specified");
+    process.exit(-1);
+}
 /*
   Function processes the input option
 


### PR DESCRIPTION
Fixes #13 

Adding a block of conditional code. Checking if config path is provided, then reading the options from the file.

If option `-c` or `--config` exists, other options are ignored! 